### PR TITLE
Fix MetaMathQA environment answer check bug

### DIFF
--- a/ragen/env/metamathqa/env.py
+++ b/ragen/env/metamathqa/env.py
@@ -59,6 +59,8 @@ class MetaMathQAEnv(BaseLanguageBasedEnv):
         if self.correct_answer:
             normalized_label = re.sub(r'\s+', '', self.correct_answer.lower())
             is_correct = normalized_answer == normalized_label
+        else:
+            is_correct = False
         is_valid = normalized_answer != ""
         return is_correct, is_valid
 


### PR DESCRIPTION
## Summary
- fix uninitialized `is_correct` in MetaMathQA environment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f67d12bf8832183df407511dcd7ea